### PR TITLE
fix zero timeout on failed condition

### DIFF
--- a/lib/Selenide/Driver.php
+++ b/lib/Selenide/Driver.php
@@ -96,6 +96,9 @@ class Driver
                 } else {
                     $resultList = $this->searchFromSecondElement($resultList, $selector);
                 }
+                if (count($resultList) == 0) {
+                    throw new Exception_ConditionMatchFailed('Not found elements');
+                }
                 $foundElement = true;
             }
             try {


### PR DESCRIPTION
Пофикшена проблема отсутствующих ожиданий. Теперь клики, асерты итд. не падают там где не должны. Если что то не успело появиться, включается 5 секундное ожидание.